### PR TITLE
Add more TimeInterpolatableBuffer specialisations

### DIFF
--- a/gen/interpolation/TimeInterpolatableBuffer.yml
+++ b/gen/interpolation/TimeInterpolatableBuffer.yml
@@ -1,4 +1,6 @@
 ---
+extra_includes:
+  - "frc/geometry/Pose3d.h"
 
 functions:
   TimeInterpolatableBuffer:
@@ -21,10 +23,26 @@ templates:
     qualname: frc::TimeInterpolatableBuffer
     params:
       - frc::Pose2d
+  TimeInterpolatablePose3dBuffer:
+    qualname: frc::TimeInterpolatableBuffer
+    params:
+      - frc::Pose3d
   TimeInterpolatableRotation2dBuffer:
     qualname: frc::TimeInterpolatableBuffer
     params:
       - frc::Rotation2d
+  TimeInterpolatableRotation3dBuffer:
+    qualname: frc::TimeInterpolatableBuffer
+    params:
+      - frc::Rotation3d
+  TimeInterpolatableTranslation2dBuffer:
+    qualname: frc::TimeInterpolatableBuffer
+    params:
+      - frc::Translation2d
+  TimeInterpolatableTranslation3dBuffer:
+    qualname: frc::TimeInterpolatableBuffer
+    params:
+      - frc::Translation3d
   TimeInterpolatableFloatBuffer:
     qualname: frc::TimeInterpolatableBuffer
     params:


### PR DESCRIPTION
This adds specialisations of `TimeInterpolatableBuffer` of various geometry classes, reflecting those of which implement the `Interpolatable` interface in Java.

~~This also adds a specialisation that takes any Python object.~~ This doesn't work; it complains about `operator*` not being implemented between `py::object` and `double`.

todo:

- [ ] tests
- [ ] improve docs?