### PR TITLE
Add general TimeInterpolatableBuffer

### DIFF
--- a/gen/interpolation/TimeInterpolatableBuffer.yml
+++ b/gen/interpolation/TimeInterpolatableBuffer.yml
@@ -25,3 +25,7 @@ templates:
     qualname: frc::TimeInterpolatableBuffer
     params:
       - double
+  TimeInterpolatableBuffer:
+    qualname: frc::TimeInterpolatableBuffer
+    params:
+      - py::object


### PR DESCRIPTION
This adds an implementation of TimeInterpolatableBuffer that takes any Python object. The constructor that doesn't take a function will take anything that implements addition and subtraction, and multiplication by floats.